### PR TITLE
🎨 Style: 文章作成フォームのデザイン+各機能を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,11 @@
 		"check:fix": "biome check --apply <files>"
 	},
 	"dependencies": {
+		"@hookform/resolvers": "^3.9.0",
 		"@radix-ui/react-checkbox": "^1.1.1",
 		"@radix-ui/react-dialog": "^1.1.1",
+		"@radix-ui/react-label": "^2.1.0",
+		"@radix-ui/react-radio-group": "^1.2.0",
 		"@radix-ui/react-select": "^2.1.1",
 		"@radix-ui/react-slot": "^1.1.0",
 		"@radix-ui/react-switch": "^1.1.0",
@@ -27,9 +30,11 @@
 		"next": "14.2.4",
 		"react": "^18",
 		"react-dom": "^18",
+		"react-hook-form": "^7.52.1",
 		"tailwind-merge": "^2.3.0",
 		"tailwindcss-animate": "^1.0.7",
-		"vaul": "^0.9.1"
+		"vaul": "^0.9.1",
+		"zod": "^3.23.8"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@radix-ui/react-switch": "^1.1.0",
 		"@radix-ui/react-tabs": "^1.1.0",
 		"@tabler/icons-react": "^3.9.0",
+		"an-array-of-english-words": "^2.0.0",
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
 		"lucide-react": "^0.400.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@tabler/icons-react':
         specifier: ^3.9.0
         version: 3.9.0(react@18.3.1)
+      an-array-of-english-words:
+        specifier: ^2.0.0
+        version: 2.0.0
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -644,6 +647,10 @@ packages:
 
   '@types/react@18.3.3':
     resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
+
+  an-array-of-english-words@2.0.0:
+    resolution: {integrity: sha512-FXnNvZSOI27kkKXeLSquhaTGP7z198UOQ4txaYO9fCfrjCh+D5SV7G7XqzEH0229+pAi4cjBEZ4WIQYgjKtO7Q==}
+    hasBin: true
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1712,6 +1719,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
+
+  an-array-of-english-words@2.0.0: {}
 
   ansi-regex@5.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,21 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^3.9.0
+        version: 3.9.0(react-hook-form@7.52.1(react@18.3.1))
       '@radix-ui/react-checkbox':
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog':
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-label':
+        specifier: ^2.1.0
+        version: 2.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.2.0
+        version: 1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-select':
         specifier: ^2.1.1
         version: 2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -47,6 +56,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.52.1
+        version: 7.52.1(react@18.3.1)
       tailwind-merge:
         specifier: ^2.3.0
         version: 2.3.0
@@ -56,6 +68,9 @@ importers:
       vaul:
         specifier: ^0.9.1
         version: 0.9.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@biomejs/biome':
         specifier: 1.8.3
@@ -156,6 +171,11 @@ packages:
 
   '@floating-ui/utils@0.2.4':
     resolution: {integrity: sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==}
+
+  '@hookform/resolvers@3.9.0':
+    resolution: {integrity: sha512-bU0Gr4EepJ/EQsH/IwEzYLsT/PEj5C0ynLQ4m+GSHS+xKH4TfSelhluTgOaoc4kA5s7eCsQbM4wvZLzELmWzUg==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -381,6 +401,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.0':
+    resolution: {integrity: sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-popper@1.2.0':
     resolution: {integrity: sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==}
     peerDependencies:
@@ -422,6 +455,19 @@ packages:
 
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.2.0':
+    resolution: {integrity: sha512-yv+oiLaicYMBpqgfpSPw6q+RyXlLdIpQWDHZbUKURxe+nEh53hFXPPlfhfQQtYkS5MMK/5IWIa76SksleQZSzw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -961,6 +1007,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-hook-form@7.52.1:
+    resolution: {integrity: sha512-uNKIhaoICJ5KQALYZ4TOaOLElyM+xipord+Ha3crEFhTntdLvWZqVY49Wqd/0GiVCA/f9NjemLeiNPjG7Hpurg==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-remove-scroll-bar@2.3.6:
     resolution: {integrity: sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==}
     engines: {node: '>=10'}
@@ -1162,6 +1214,9 @@ packages:
     engines: {node: '>= 14'}
     hasBin: true
 
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -1221,6 +1276,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/utils@0.2.4': {}
+
+  '@hookform/resolvers@3.9.0(react-hook-form@7.52.1(react@18.3.1))':
+    dependencies:
+      react-hook-form: 7.52.1(react@18.3.1)
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -1410,6 +1469,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
+  '@radix-ui/react-label@2.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-popper@1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1451,6 +1519,24 @@ snapshots:
   '@radix-ui/react-primitive@2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-radio-group@1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.3)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -1945,6 +2031,10 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-hook-form@7.52.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   react-remove-scroll-bar@2.3.6(@types/react@18.3.3)(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -2150,3 +2240,5 @@ snapshots:
       strip-ansi: 7.1.0
 
   yaml@2.4.5: {}
+
+  zod@3.23.8: {}

--- a/src/components/Ui/Alert.tsx
+++ b/src/components/Ui/Alert.tsx
@@ -1,0 +1,59 @@
+import { type VariantProps, cva } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+	"relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+	{
+		variants: {
+			variant: {
+				default: "bg-background text-foreground",
+				destructive:
+					"border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	},
+);
+
+const Alert = React.forwardRef<
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+	<div
+		ref={ref}
+		role="alert"
+		className={cn(alertVariants({ variant }), className)}
+		{...props}
+	/>
+));
+Alert.displayName = "Alert";
+
+const AlertTitle = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+	<h5
+		ref={ref}
+		className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+		{...props}
+	/>
+));
+AlertTitle.displayName = "AlertTitle";
+
+const AlertDescription = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+	<div
+		ref={ref}
+		className={cn("text-sm [&_p]:leading-relaxed", className)}
+		{...props}
+	/>
+));
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertTitle, AlertDescription };

--- a/src/components/Ui/Form.tsx
+++ b/src/components/Ui/Form.tsx
@@ -1,0 +1,177 @@
+import type * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import {
+	Controller,
+	type ControllerProps,
+	type FieldPath,
+	type FieldValues,
+	FormProvider,
+	useFormContext,
+} from "react-hook-form";
+
+import { cn } from "@/lib/utils";
+import { Label } from "./label";
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+	TFieldValues extends FieldValues = FieldValues,
+	TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+	name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+	{} as FormFieldContextValue,
+);
+
+const FormField = <
+	TFieldValues extends FieldValues = FieldValues,
+	TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+	...props
+}: ControllerProps<TFieldValues, TName>) => {
+	return (
+		<FormFieldContext.Provider value={{ name: props.name }}>
+			<Controller {...props} />
+		</FormFieldContext.Provider>
+	);
+};
+
+const useFormField = () => {
+	const fieldContext = React.useContext(FormFieldContext);
+	const itemContext = React.useContext(FormItemContext);
+	const { getFieldState, formState } = useFormContext();
+
+	const fieldState = getFieldState(fieldContext.name, formState);
+
+	if (!fieldContext) {
+		throw new Error("useFormField should be used within <FormField>");
+	}
+
+	const { id } = itemContext;
+
+	return {
+		id,
+		name: fieldContext.name,
+		formItemId: `${id}-form-item`,
+		formDescriptionId: `${id}-form-item-description`,
+		formMessageId: `${id}-form-item-message`,
+		...fieldState,
+	};
+};
+
+type FormItemContextValue = {
+	id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+	{} as FormItemContextValue,
+);
+
+const FormItem = React.forwardRef<
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+	const id = React.useId();
+
+	return (
+		<FormItemContext.Provider value={{ id }}>
+			<div ref={ref} className={cn("space-y-2", className)} {...props} />
+		</FormItemContext.Provider>
+	);
+});
+FormItem.displayName = "FormItem";
+
+const FormLabel = React.forwardRef<
+	React.ElementRef<typeof LabelPrimitive.Root>,
+	React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+	const { error, formItemId } = useFormField();
+
+	return (
+		<Label
+			ref={ref}
+			className={cn(error && "text-destructive", className)}
+			htmlFor={formItemId}
+			{...props}
+		/>
+	);
+});
+FormLabel.displayName = "FormLabel";
+
+const FormControl = React.forwardRef<
+	React.ElementRef<typeof Slot>,
+	React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+	const { error, formItemId, formDescriptionId, formMessageId } =
+		useFormField();
+
+	return (
+		<Slot
+			ref={ref}
+			id={formItemId}
+			aria-describedby={
+				!error
+					? `${formDescriptionId}`
+					: `${formDescriptionId} ${formMessageId}`
+			}
+			aria-invalid={!!error}
+			{...props}
+		/>
+	);
+});
+FormControl.displayName = "FormControl";
+
+const FormDescription = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+	const { formDescriptionId } = useFormField();
+
+	return (
+		<p
+			ref={ref}
+			id={formDescriptionId}
+			className={cn("text-sm text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+});
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+	const { error, formMessageId } = useFormField();
+	const body = error ? String(error?.message) : children;
+
+	if (!body) {
+		return null;
+	}
+
+	return (
+		<p
+			ref={ref}
+			id={formMessageId}
+			className={cn("text-sm font-medium text-destructive", className)}
+			{...props}
+		>
+			{body}
+		</p>
+	);
+});
+FormMessage.displayName = "FormMessage";
+
+export {
+	useFormField,
+	Form,
+	FormItem,
+	FormLabel,
+	FormControl,
+	FormDescription,
+	FormMessage,
+	FormField,
+};

--- a/src/components/Ui/Form.tsx
+++ b/src/components/Ui/Form.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-hook-form";
 
 import { cn } from "@/lib/utils";
-import { Label } from "./label";
+import { Label } from "./Label";
 
 const Form = FormProvider;
 

--- a/src/components/Ui/Label.tsx
+++ b/src/components/Ui/Label.tsx
@@ -1,0 +1,24 @@
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { type VariantProps, cva } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const labelVariants = cva(
+	"text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+);
+
+const Label = React.forwardRef<
+	React.ElementRef<typeof LabelPrimitive.Root>,
+	React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+		VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+	<LabelPrimitive.Root
+		ref={ref}
+		className={cn(labelVariants(), className)}
+		{...props}
+	/>
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/src/components/Ui/Label.tsx
+++ b/src/components/Ui/Label.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const labelVariants = cva(
-	"text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+	"leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
 );
 
 const Label = React.forwardRef<

--- a/src/components/Ui/RadioGroup.tsx
+++ b/src/components/Ui/RadioGroup.tsx
@@ -1,0 +1,42 @@
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { Circle } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const RadioGroup = React.forwardRef<
+	React.ElementRef<typeof RadioGroupPrimitive.Root>,
+	React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+	return (
+		<RadioGroupPrimitive.Root
+			className={cn("grid gap-2", className)}
+			{...props}
+			ref={ref}
+		/>
+	);
+});
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+	React.ElementRef<typeof RadioGroupPrimitive.Item>,
+	React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+	return (
+		<RadioGroupPrimitive.Item
+			ref={ref}
+			className={cn(
+				"aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+				className,
+			)}
+			{...props}
+		>
+			<RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+				<Circle className="h-2.5 w-2.5 fill-current text-current" />
+			</RadioGroupPrimitive.Indicator>
+		</RadioGroupPrimitive.Item>
+	);
+});
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/src/components/Ui/RadioGroup.tsx
+++ b/src/components/Ui/RadioGroup.tsx
@@ -26,13 +26,13 @@ const RadioGroupItem = React.forwardRef<
 		<RadioGroupPrimitive.Item
 			ref={ref}
 			className={cn(
-				"aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+				"aspect-square h-5 w-5 rounded-full border border-blue-500 text-blue-500 ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
 				className,
 			)}
 			{...props}
 		>
 			<RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-				<Circle className="h-2.5 w-2.5 fill-current text-current" />
+				<Circle className="h-3 w-3 rounded-full bg-blue-500" />
 			</RadioGroupPrimitive.Indicator>
 		</RadioGroupPrimitive.Item>
 	);

--- a/src/pages/texts/create/components/InputWithEnter.tsx
+++ b/src/pages/texts/create/components/InputWithEnter.tsx
@@ -1,7 +1,7 @@
 import { Badge } from "@/components/Ui/Badge";
 import { Input as BaseInput } from "@/components/Ui/Input";
 import { cn } from "@/lib/utils";
-import words from "an-array-of-english-words"; // インポート
+import words from "an-array-of-english-words";
 import React, { useState } from "react";
 
 export interface InputWithEnterProps
@@ -96,4 +96,4 @@ const InputWithEnter = React.forwardRef<HTMLInputElement, InputWithEnterProps>(
 
 InputWithEnter.displayName = "InputWithEnter";
 
-export { InputWithEnter };
+export default InputWithEnter;

--- a/src/pages/texts/create/components/InputWithEnter.tsx
+++ b/src/pages/texts/create/components/InputWithEnter.tsx
@@ -1,0 +1,52 @@
+import { Badge } from "@/components/Ui/Badge";
+import { Input as BaseInput } from "@/components/Ui/Input";
+import { cn } from "@/lib/utils";
+import React, { useState } from "react";
+
+export interface InputWithEnterProps
+	extends React.InputHTMLAttributes<HTMLInputElement> {
+	onEnter: (value: string) => void;
+}
+
+const InputWithEnter = React.forwardRef<HTMLInputElement, InputWithEnterProps>(
+	({ className, onEnter, ...props }, ref) => {
+		const [inputValue, setInputValue] = useState("");
+
+		const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+			if (e.key === "Enter") {
+				onEnter(inputValue);
+				setInputValue("");
+				e.preventDefault();
+			}
+		};
+
+		const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+			setInputValue(e.target.value);
+		};
+
+		return (
+			<div className="relative">
+				<BaseInput
+					value={inputValue}
+					placeholder="learn, study, read..."
+					onChange={handleChange}
+					onKeyDown={handleKeyDown}
+					className={cn(
+						"flex h-10 w-full rounded-full border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+						className,
+					)}
+					ref={ref}
+					{...props}
+				/>
+				{inputValue && (
+					<Badge className="absolute right-2 top-1/2 transform -translate-y-1/2">
+						Enterで追加
+					</Badge>
+				)}
+			</div>
+		);
+	},
+);
+InputWithEnter.displayName = "InputWithEnter";
+
+export { InputWithEnter };

--- a/src/pages/texts/create/components/TextForm.tsx
+++ b/src/pages/texts/create/components/TextForm.tsx
@@ -82,9 +82,12 @@ const TextForm = () => {
 							<FormControl>
 								<InputWithEnter id="words" onEnter={handleEnter} />
 							</FormControl>
-							<ul className="flex space-x-2 mt-2">
+							<ul className="flex flex-wrap gap-2 mt-2">
 								{wordList.map((word) => (
-									<Badge key={word} className="text-sm flex items-center">
+									<Badge
+										key={word}
+										className="text-sm flex items-center max-w-xs break-words"
+									>
 										{word}
 										<IconX
 											className="w-4 h-4 ml-1 cursor-pointer"

--- a/src/pages/texts/create/components/TextForm.tsx
+++ b/src/pages/texts/create/components/TextForm.tsx
@@ -1,0 +1,206 @@
+import { Button } from "@/components/Ui/Button";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/Ui/Form";
+import { Input } from "@/components/Ui/Input";
+import { Label } from "@/components/Ui/Label";
+import { RadioGroup, RadioGroupItem } from "@/components/Ui/RadioGroup";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import { z } from "zod";
+
+const formSchema = z.object({
+	words: z
+		.array(z.string())
+		.min(1, { message: "英単語を入力してください" })
+		.max(5, { message: "英単語は５つまで選択できます" }),
+	level: z.string(),
+	theme: z.string(),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+const TextForm = () => {
+	const form = useForm<FormData>({
+		resolver: zodResolver(formSchema),
+		defaultValues: {
+			words: [],
+			level: "225",
+			theme: "business",
+		},
+	});
+
+	const onSubmit: SubmitHandler<FormData> = (data) => {
+		console.log(data);
+	};
+
+	return (
+		<Form {...form}>
+			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+				<FormField
+					name="words"
+					control={form.control}
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel htmlFor="words" className="text-lg">
+								使用する英単語を入力してください(5つまで)
+							</FormLabel>
+							<FormControl>
+								<Input id="words" {...field} />
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					name="level"
+					control={form.control}
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel htmlFor="level" className="text-lg">
+								難易度を選択してください
+							</FormLabel>
+							<FormControl>
+								<RadioGroup
+									id="level"
+									name="level"
+									value={field.value}
+									onValueChange={(value) => field.onChange(value)}
+								>
+									<div className="space-y-2">
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="225" id="r1" />
+											<Label htmlFor="r1" className="cursor-pointer">
+												TOEIC(~225)
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="226-550" id="r2" />
+											<Label htmlFor="r2" className="cursor-pointer">
+												TOEIC(226~550)
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="551-750" id="r3" />
+											<Label htmlFor="r3" className="cursor-pointer">
+												TOEIC(551~750)
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="751-900" id="r4" />
+											<Label htmlFor="r4" className="cursor-pointer">
+												TOEIC(751~900)
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="901" id="r5" />
+											<Label htmlFor="r5" className="cursor-pointer">
+												TOEIC(901~)
+											</Label>
+										</div>
+									</div>
+								</RadioGroup>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					name="theme"
+					control={form.control}
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel htmlFor="theme" className="text-lg">
+								テーマを選択してください
+							</FormLabel>
+							<FormControl>
+								<RadioGroup
+									id="theme"
+									name="theme"
+									value={field.value}
+									onValueChange={(value) => field.onChange(value)}
+								>
+									<div className="space-y-2">
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="business" id="r6" />
+											<Label htmlFor="r6" className="cursor-pointer">
+												ビジネス
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="travel" id="r7" />
+											<Label htmlFor="r7" className="cursor-pointer">
+												旅行
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="health" id="r8" />
+											<Label htmlFor="r8" className="cursor-pointer">
+												健康
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="technology" id="r9" />
+											<Label htmlFor="r9" className="cursor-pointer">
+												テクノロジー
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="education" id="r10" />
+											<Label htmlFor="r10" className="cursor-pointer">
+												教育
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="daily-life" id="r11" />
+											<Label htmlFor="r11" className="cursor-pointer">
+												日常生活
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="art-literature" id="r12" />
+											<Label htmlFor="r12" className="cursor-pointer">
+												アートと文学
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="entertainment" id="r13" />
+											<Label htmlFor="r13" className="cursor-pointer">
+												エンターテイメント
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="environment" id="r14" />
+											<Label htmlFor="r14" className="cursor-pointer">
+												環境
+											</Label>
+										</div>
+										<div className="flex items-center space-x-1">
+											<RadioGroupItem value="history" id="r15" />
+											<Label htmlFor="r15" className="cursor-pointer">
+												歴史
+											</Label>
+										</div>
+									</div>
+								</RadioGroup>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<div className="flex justify-center space-x-1">
+					<Button className="text-2xl my-4" size="lg" type="submit">
+						文章を作成する
+					</Button>
+				</div>
+			</form>
+		</Form>
+	);
+};
+
+export default TextForm;

--- a/src/pages/texts/create/components/TextForm.tsx
+++ b/src/pages/texts/create/components/TextForm.tsx
@@ -16,7 +16,7 @@ import { IconX } from "@tabler/icons-react";
 import { useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { z } from "zod";
-import { InputWithEnter } from "./InputWithEnter";
+import InputWithEnter from "./InputWithEnter";
 
 const formSchema = z.object({
 	words: z

--- a/src/pages/texts/create/index.tsx
+++ b/src/pages/texts/create/index.tsx
@@ -1,0 +1,16 @@
+import { IconFileTextAi } from "@tabler/icons-react";
+import TextForm from "./components/TextForm";
+
+export default function TextCreate() {
+	return (
+		<div className="max-w-screen-lg mx-auto">
+			<div className="mx-2">
+				<div className="flex text-2xl font-bold my-5">
+					<IconFileTextAi className="w-7 h-7" />
+					<h1>文章作成</h1>
+				</div>
+				<TextForm />
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
文章作成フォームのデザインとさまざまなバリテーション、英単語のサジェスト機能を作成。

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1]フォームのデザインを作成
- [変更点2]英単語が複数選べるように
- [変更点3]英単語のサジェスト機能を実装

## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [x] フォームのデザインの確認
- [x] Input要素の英単語サジェストを実装
- [x] 英単語未入力のバリテーションがかかっているか？

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->
- Closes #15 
- Relates to #16 

## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->
- [Form](https://ui.shadcn.com/docs/components/form)
- [zod](https://zod.dev/?id=element)
- [react-hook-form](https://zenn.dev/uzimaru0000/articles/react-hook-form-with-zod)
- [htmlForについて](https://zenn.dev/kimura141899/articles/6e11e3a165460d)

## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->
[![Image from Gyazo](https://i.gyazo.com/8e92be01a6f709a976e234a50ea77b15.png)](https://gyazo.com/8e92be01a6f709a976e234a50ea77b15)
[![Image from Gyazo](https://i.gyazo.com/20b6b66cde96c5f2d1b2c789586865ed.png)](https://gyazo.com/20b6b66cde96c5f2d1b2c789586865ed)
## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->
英単語が長すぎるとXアイコンが消えるのでそのバグも修正しないといけない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - アラート機能を追加しました。（`Alert`, `AlertTitle`, `AlertDescription`）
  - フォーム構築用コンポーネントを追加しました。（`Form`, `FormItem`, `FormLabel`, `FormControl`, `FormDescription`, `FormMessage`, `FormField`）
  - カスタムラジオグループコンポーネントを追加しました。（`RadioGroup`, `RadioGroupItem`）
  - Enterキーでアクションをトリガーする入力フィールドを追加しました。（`InputWithEnter`）
  - テキスト作成用フォームコンポーネントを追加しました。（`TextForm`）
  - テキスト作成ページを追加しました。（`TextCreate`）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->