### PR TITLE
🚪 Feat: supabaseのセットアップ+認証ユーザーを登録できるように

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
 		"@radix-ui/react-slot": "^1.1.0",
 		"@radix-ui/react-tabs": "^1.1.0",
 		"@radix-ui/react-toggle": "^1.1.0",
+		"@supabase/auth-ui-react": "^0.4.7",
+		"@supabase/auth-ui-shared": "^0.1.8",
 		"@supabase/ssr": "^0.4.0",
 		"@supabase/supabase-js": "^2.44.4",
 		"@tabler/icons-react": "^3.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,12 @@ importers:
       '@radix-ui/react-toggle':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@supabase/auth-ui-react':
+        specifier: ^0.4.7
+        version: 0.4.7(@supabase/supabase-js@2.44.4)
+      '@supabase/auth-ui-shared':
+        specifier: ^0.1.8
+        version: 0.1.8(@supabase/supabase-js@2.44.4)
       '@supabase/ssr':
         specifier: ^0.4.0
         version: 0.4.0(@supabase/supabase-js@2.44.4)
@@ -704,8 +710,21 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@stitches/core@1.2.8':
+    resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
+
   '@supabase/auth-js@2.64.4':
     resolution: {integrity: sha512-9ITagy4WP4FLl+mke1rchapOH0RQpf++DI+WSG2sO1OFOZ0rW3cwAM0nCrMOxu+Zw4vJ4zObc08uvQrXx590Tg==}
+
+  '@supabase/auth-ui-react@0.4.7':
+    resolution: {integrity: sha512-Lp4FQGFh7BMX1Y/BFaUKidbryL7eskj1fl6Lby7BeHrTctbdvDbCMjVKS8wZ2rxuI8FtPS2iU900fSb70FHknQ==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.21.0
+
+  '@supabase/auth-ui-shared@0.1.8':
+    resolution: {integrity: sha512-ouQ0DjKcEFg+0gZigFIEgu01V3e6riGZPzgVD0MJsCBNsMsiDT74+GgCEIElMUpTGkwSja3xLwdFRFgMNFKcjg==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.21.0
 
   '@supabase/functions-js@2.4.1':
     resolution: {integrity: sha512-8sZ2ibwHlf+WkHDUZJUXqqmPvWQ3UHN0W30behOJngVh/qHHekhJLCFbh0AjkE9/FqqXtf9eoVvmYgfCLk5tNA==}
@@ -1125,6 +1144,9 @@ packages:
     resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -1138,6 +1160,9 @@ packages:
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-remove-scroll-bar@2.3.6:
     resolution: {integrity: sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==}
@@ -1912,9 +1937,24 @@ snapshots:
   '@rollup/rollup-linux-x64-gnu@4.18.1':
     optional: true
 
+  '@stitches/core@1.2.8': {}
+
   '@supabase/auth-js@2.64.4':
     dependencies:
       '@supabase/node-fetch': 2.6.15
+
+  '@supabase/auth-ui-react@0.4.7(@supabase/supabase-js@2.44.4)':
+    dependencies:
+      '@stitches/core': 1.2.8
+      '@supabase/auth-ui-shared': 0.1.8(@supabase/supabase-js@2.44.4)
+      '@supabase/supabase-js': 2.44.4
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@supabase/auth-ui-shared@0.1.8(@supabase/supabase-js@2.44.4)':
+    dependencies:
+      '@supabase/supabase-js': 2.44.4
 
   '@supabase/functions-js@2.4.1':
     dependencies:
@@ -2310,6 +2350,12 @@ snapshots:
       picocolors: 1.0.1
       source-map-js: 1.2.0
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   queue-microtask@1.2.3: {}
 
   react-dom@18.3.1(react@18.3.1):
@@ -2321,6 +2367,8 @@ snapshots:
   react-hook-form@7.52.1(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  react-is@16.13.1: {}
 
   react-remove-scroll-bar@2.3.6(@types/react@18.3.3)(react@18.3.1):
     dependencies:

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -1,13 +1,15 @@
 import Image from "next/image";
 import logo from "../../../public/logo.webp";
-import Menu from "./Menu";
+import LoginModal from "./LoginModal";
+import RegisterModal from "./RegisterModal";
 
 const Header = () => {
 	return (
 		<header className="flex justify-end items-center border-b border-gray-200 p-2">
 			<Image src={logo} alt="logo" height={30} />
 			<div className="ml-auto">
-				<Menu />
+				<LoginModal />
+				<RegisterModal />
 			</div>
 		</header>
 	);

--- a/src/components/Layout/Header/LoginModal.tsx
+++ b/src/components/Layout/Header/LoginModal.tsx
@@ -1,4 +1,15 @@
+import {
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/Ui/Form";
+import { supabase } from "@/lib/supabase";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { IconBrandGoogle, IconX } from "@tabler/icons-react";
+import { FormProvider, useForm } from "react-hook-form";
+import { z } from "zod";
 import {
 	AlertDialog,
 	AlertDialogCancel,
@@ -11,7 +22,46 @@ import {
 import { Button } from "../../Ui/Button";
 import { Input } from "../../Ui/Input";
 
+const schema = z.object({
+	email: z
+		.string()
+		.nonempty({ message: "メールアドレスを入力してください" })
+		.email({ message: "有効なメールアドレスを入力してください" }),
+	password: z.string().min(8, { message: "パスワードは8文字以上です" }),
+});
+
+type FormData = z.infer<typeof schema>;
+
 const LoginModal = () => {
+	const methods = useForm<FormData>({
+		resolver: zodResolver(schema),
+	});
+
+	const {
+		handleSubmit,
+		formState: { errors, isValid },
+		reset,
+	} = methods;
+
+	const onSubmit = async (data: FormData) => {
+		try {
+			const { email, password } = data;
+			const { error } = await supabase.auth.signInWithPassword({
+				email,
+				password,
+			});
+
+			if (error) {
+				throw new Error(error.message);
+			}
+			console.log("Login successful");
+		} catch (err) {
+			console.error(err);
+		} finally {
+			reset();
+		}
+	};
+
 	return (
 		<AlertDialog>
 			<AlertDialogTrigger asChild>
@@ -26,23 +76,66 @@ const LoginModal = () => {
 						<IconX />
 					</AlertDialogCancel>
 				</AlertDialogHeader>
-				<Input className="rounded" placeholder="メールアドレス" />
-				<Input className="rounded" placeholder="パスワード" />
-				<AlertDialogDescription className="text-center">
-					パスワードを忘れた方はこちら
-				</AlertDialogDescription>
-				<div className="flex flex-col space-y-2">
-					<Button>ログイン</Button>
-					<div className="flex items-center">
-						<hr className="flex-grow border-gray-300" />
-						<p className="px-2 text-gray-400">または</p>
-						<hr className="flex-grow border-gray-300" />
-					</div>
-					<Button>
-						<IconBrandGoogle className="mr-2" />
-						Googleアカウントで新規登録
-					</Button>
-				</div>
+				<FormProvider {...methods}>
+					<form onSubmit={handleSubmit(onSubmit)}>
+						<FormField
+							name="email"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Email</FormLabel>
+									<FormControl>
+										<Input
+											className="rounded"
+											placeholder="example@gmail.com"
+											{...field}
+										/>
+									</FormControl>
+									{errors.email && (
+										<FormMessage>{errors.email.message}</FormMessage>
+									)}
+								</FormItem>
+							)}
+						/>
+
+						<FormField
+							name="password"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Password</FormLabel>
+									<FormControl>
+										<Input
+											type="password"
+											className="rounded"
+											placeholder="8 characters or more"
+											{...field}
+										/>
+									</FormControl>
+									{errors.password && (
+										<FormMessage>{errors.password.message}</FormMessage>
+									)}
+								</FormItem>
+							)}
+						/>
+
+						<AlertDialogDescription className="text-center">
+							パスワードを忘れた方はこちら
+						</AlertDialogDescription>
+						<div className="flex flex-col space-y-2">
+							<Button type="submit" variant={isValid ? "default" : "disabled"}>
+								ログイン
+							</Button>
+							<div className="flex items-center">
+								<hr className="flex-grow border-gray-300" />
+								<p className="px-2 text-gray-400">または</p>
+								<hr className="flex-grow border-gray-300" />
+							</div>
+							<Button>
+								<IconBrandGoogle className="mr-2" />
+								Googleアカウントでログイン
+							</Button>
+						</div>
+					</form>
+				</FormProvider>
 				<AlertDialogDescription className="text-center">
 					新規登録の方はこちら
 				</AlertDialogDescription>

--- a/src/components/Layout/Header/RegisterModal.tsx
+++ b/src/components/Layout/Header/RegisterModal.tsx
@@ -1,4 +1,15 @@
+import {
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/Ui/Form";
+import { supabase } from "@/lib/supabase";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { IconBrandGoogle, IconX } from "@tabler/icons-react";
+import { FormProvider, useForm } from "react-hook-form";
+import { z } from "zod";
 import {
 	AlertDialog,
 	AlertDialogCancel,
@@ -11,7 +22,57 @@ import {
 import { Button } from "../../Ui/Button";
 import { Input } from "../../Ui/Input";
 
+const schema = z
+	.object({
+		name: z.string().nonempty({ message: "名前を入力してください" }),
+		email: z
+			.string()
+			.nonempty({ message: "メールアドレスを入力してください" })
+			.email({ message: "有効なメールアドレスを入力してください" }),
+		password: z
+			.string()
+			.min(8, { message: "パスワードは8文字以上で入力してください" }),
+		confirmPassword: z
+			.string()
+			.min(8, { message: "確認パスワードは8文字以上で入力してください" }),
+	})
+	.refine((data) => data.password === data.confirmPassword, {
+		message: "パスワードが一致しません",
+		path: ["confirmPassword"],
+	});
+
+type FormData = z.infer<typeof schema>;
+
 const RegisterModal = () => {
+	const methods = useForm<FormData>({
+		resolver: zodResolver(schema),
+	});
+
+	const {
+		handleSubmit,
+		formState: { errors, isValid },
+		reset,
+	} = methods;
+
+	const onSubmit = async (data: FormData) => {
+		try {
+			const { email, password } = data;
+			const { error } = await supabase.auth.signUp({
+				email,
+				password,
+			});
+
+			if (error) {
+				throw new Error(error.message);
+			}
+			console.log("Registration successful");
+		} catch (err) {
+			console.error(err);
+		} finally {
+			reset();
+		}
+	};
+
 	return (
 		<AlertDialog>
 			<AlertDialogTrigger asChild>
@@ -26,25 +87,105 @@ const RegisterModal = () => {
 						<IconX />
 					</AlertDialogCancel>
 				</AlertDialogHeader>
-				<Input className="rounded" placeholder="メールアドレス" />
-				<Input className="rounded" placeholder="パスワード" />
-				<Input className="rounded" placeholder="パスワード(確認)" />
-				<AlertDialogDescription>
-					利用規約およびプライバシーポリシーに同意した上で、
-					以下の「登録」ボタンを押してください。
-				</AlertDialogDescription>
-				<div className="flex flex-col space-y-2">
-					<Button>新規登録</Button>
-					<div className="flex items-center">
-						<hr className="flex-grow border-gray-300" />
-						<p className="px-2 text-gray-400">または</p>
-						<hr className="flex-grow border-gray-300" />
-					</div>
-					<Button>
-						<IconBrandGoogle className="mr-2" />
-						Googleアカウントで新規登録
-					</Button>
-				</div>
+				<FormProvider {...methods}>
+					<form onSubmit={handleSubmit(onSubmit)}>
+						<FormField
+							name="name"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Name</FormLabel>
+									<FormControl>
+										<Input
+											className="rounded"
+											placeholder="john doe"
+											{...field}
+										/>
+									</FormControl>
+									{errors.name && (
+										<FormMessage>{errors.name.message}</FormMessage>
+									)}
+								</FormItem>
+							)}
+						/>
+
+						<FormField
+							name="email"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Email</FormLabel>
+									<FormControl>
+										<Input
+											className="rounded"
+											placeholder="example@gmail.com"
+											{...field}
+										/>
+									</FormControl>
+									{errors.email && (
+										<FormMessage>{errors.email.message}</FormMessage>
+									)}
+								</FormItem>
+							)}
+						/>
+
+						<FormField
+							name="password"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Password</FormLabel>
+									<FormControl>
+										<Input
+											type="password"
+											className="rounded"
+											placeholder="8 characters or more"
+											{...field}
+										/>
+									</FormControl>
+									{errors.password && (
+										<FormMessage>{errors.password.message}</FormMessage>
+									)}
+								</FormItem>
+							)}
+						/>
+
+						<FormField
+							name="confirmPassword"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Confirm Password</FormLabel>
+									<FormControl>
+										<Input
+											type="password"
+											className="rounded"
+											placeholder="confirmation"
+											{...field}
+										/>
+									</FormControl>
+									{errors.confirmPassword && (
+										<FormMessage>{errors.confirmPassword.message}</FormMessage>
+									)}
+								</FormItem>
+							)}
+						/>
+
+						<AlertDialogDescription>
+							利用規約およびプライバシーポリシーに同意した上で、以下の「登録」ボタンを押してください。
+						</AlertDialogDescription>
+						<div className="flex flex-col space-y-2">
+							<Button type="submit" variant={isValid ? "default" : "disabled"}>
+								新規登録
+							</Button>
+							<div className="flex items-center">
+								<hr className="flex-grow border-gray-300" />
+								<p className="px-2 text-gray-400">または</p>
+								<hr className="flex-grow border-gray-300" />
+							</div>
+							<Button>
+								<IconBrandGoogle className="mr-2" />
+								Googleアカウントで新規登録
+							</Button>
+						</div>
+					</form>
+				</FormProvider>
 				<AlertDialogDescription className="text-center">
 					登録済みの方はこちら
 				</AlertDialogDescription>

--- a/src/components/Ui/Button.tsx
+++ b/src/components/Ui/Button.tsx
@@ -18,6 +18,7 @@ const buttonVariants = cva(
 					"bg-secondary text-secondary-foreground hover:bg-secondary/80",
 				ghost: "hover:bg-accent hover:text-accent-foreground",
 				link: "text-primary underline-offset-4 hover:underline",
+				disabled: "bg-blue-300 text-primary-foreground cursor-not-allowed",
 			},
 			size: {
 				default: "h-10 px-4 py-2",

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,7 @@
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "../types/supabase";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "";
+
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey);

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,109 @@
+export type Json =
+	| string
+	| number
+	| boolean
+	| null
+	| { [key: string]: Json | undefined }
+	| Json[];
+
+export type Database = {
+	public: {
+		Tables: {
+			[_ in never]: never;
+		};
+		Views: {
+			[_ in never]: never;
+		};
+		Functions: {
+			[_ in never]: never;
+		};
+		Enums: {
+			UserRole: "FREE" | "STANDARD" | "ADMIN";
+		};
+		CompositeTypes: {
+			[_ in never]: never;
+		};
+	};
+};
+
+type PublicSchema = Database[Extract<keyof Database, "public">];
+
+export type Tables<
+	PublicTableNameOrOptions extends
+		| keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+		| { schema: keyof Database },
+	TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+		? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+				Database[PublicTableNameOrOptions["schema"]]["Views"])
+		: never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+	? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+			Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+			Row: infer R;
+		}
+		? R
+		: never
+	: PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+				PublicSchema["Views"])
+		? (PublicSchema["Tables"] &
+				PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+				Row: infer R;
+			}
+			? R
+			: never
+		: never;
+
+export type TablesInsert<
+	PublicTableNameOrOptions extends
+		| keyof PublicSchema["Tables"]
+		| { schema: keyof Database },
+	TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+		? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+		: never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+	? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+			Insert: infer I;
+		}
+		? I
+		: never
+	: PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+		? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+				Insert: infer I;
+			}
+			? I
+			: never
+		: never;
+
+export type TablesUpdate<
+	PublicTableNameOrOptions extends
+		| keyof PublicSchema["Tables"]
+		| { schema: keyof Database },
+	TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+		? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+		: never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+	? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+			Update: infer U;
+		}
+		? U
+		: never
+	: PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+		? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+				Update: infer U;
+			}
+			? U
+			: never
+		: never;
+
+export type Enums<
+	PublicEnumNameOrOptions extends
+		| keyof PublicSchema["Enums"]
+		| { schema: keyof Database },
+	EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+		? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+		: never = never,
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+	? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+	: PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+		? PublicSchema["Enums"][PublicEnumNameOrOptions]
+		: never;


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
Email認証でユーザー登録がsupabase上で行えるように

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1]supabase関数のセットアップ
- [変更点2]supabase関数を使って、ユーザー登録。

## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [ ] 環境変数をセットアップするとモーダルの新規登録ボタンでauth.userが作られること。

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->
- Closes #123
- Relates to #456

## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->
- [supabase認証機能の実装](https://zenn.dev/sc30gsw/articles/56e07707a4f55b)

## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->

## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->
一応、supabaseに認証テーブルが追加されることは確認できた。これから
- session情報を用いて、headerの切り替え
- 登録時にpuliec.userの作成
などを行う必要がある。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ヘッダーにログインおよび登録モーダルを追加し、ユーザー認証を簡素化しました。
	- より構造化されたフォームと検証機能を備えたログインおよび登録プロセスを実装しました。
	- ボタンに「無効」状態のスタイルを追加し、視覚的フィードバックを強化しました。

- **依存関係の追加**
	- 認証機能を強化するために、Supabaseの新しい依存関係を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->