### PR TITLE
🎨 Headerデザインでログインのみに変更

### DIFF
--- a/src/components/Layout/Header/LoginModal.tsx
+++ b/src/components/Layout/Header/LoginModal.tsx
@@ -1,57 +1,23 @@
-import {
-	FormControl,
-	FormField,
-	FormItem,
-	FormLabel,
-	FormMessage,
-} from "@/components/Ui/Form";
-import { zodResolver } from "@hookform/resolvers/zod";
+import {} from "@/components/Ui/Form";
 import { IconBrandGoogle, IconX } from "@tabler/icons-react";
 import { signIn } from "next-auth/react";
-import { FormProvider, useForm } from "react-hook-form";
-import { z } from "zod";
+import Image from "next/image";
+import logo from "../../../public/logo.webp";
 import {
 	AlertDialog,
 	AlertDialogCancel,
 	AlertDialogContent,
-	AlertDialogDescription,
 	AlertDialogHeader,
 	AlertDialogTitle,
 	AlertDialogTrigger,
 } from "../../Ui/AlertDialog";
 import { Button } from "../../Ui/Button";
-import { Input } from "../../Ui/Input";
-
-const schema = z.object({
-	email: z
-		.string()
-		.nonempty({ message: "メールアドレスを入力してください" })
-		.email({ message: "有効なメールアドレスを入力してください" }),
-	password: z.string().min(8, { message: "パスワードは8文字以上です" }),
-});
-
-type FormData = z.infer<typeof schema>;
 
 const LoginModal = () => {
-	const methods = useForm<FormData>({
-		resolver: zodResolver(schema),
-	});
-
-	const {
-		handleSubmit,
-		formState: { errors, isValid },
-		reset,
-	} = methods;
-
-	const onSubmit = (data: FormData) => {
-		console.log("Login form submitted", data);
-		reset();
-	};
-
 	return (
 		<AlertDialog>
 			<AlertDialogTrigger asChild>
-				<Button className="mr-2" variant="ghost" size="xs">
+				<Button className="mr-2" size="xs">
 					ログイン
 				</Button>
 			</AlertDialogTrigger>
@@ -62,71 +28,18 @@ const LoginModal = () => {
 						<IconX />
 					</AlertDialogCancel>
 				</AlertDialogHeader>
-				<FormProvider {...methods}>
-					<form onSubmit={handleSubmit(onSubmit)}>
-						<FormField
-							name="email"
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel>Email</FormLabel>
-									<FormControl>
-										<Input
-											className="rounded"
-											placeholder="example@gmail.com"
-											{...field}
-										/>
-									</FormControl>
-									{errors.email && (
-										<FormMessage>{errors.email.message}</FormMessage>
-									)}
-								</FormItem>
-							)}
-						/>
-
-						<FormField
-							name="password"
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel>Password</FormLabel>
-									<FormControl>
-										<Input
-											type="password"
-											className="rounded"
-											placeholder="8 characters or more"
-											{...field}
-										/>
-									</FormControl>
-									{errors.password && (
-										<FormMessage>{errors.password.message}</FormMessage>
-									)}
-								</FormItem>
-							)}
-						/>
-
-						<AlertDialogDescription className="text-center">
-							パスワードを忘れた方はこちら
-						</AlertDialogDescription>
-						<div className="flex flex-col space-y-2">
-							<Button type="submit" variant={isValid ? "default" : "disabled"}>
-								ログイン
-							</Button>
-						</div>
-					</form>
-				</FormProvider>
-				<div className="flex items-center">
-					<hr className="flex-grow border-gray-300" />
-					<p className="px-2 text-gray-400">または</p>
-					<hr className="flex-grow border-gray-300" />
+				<div className="flex justify-center">
+					<Image src={logo} alt="logo" width={300} />
 				</div>
+				<p className="text-sm">
+					覚えたい英単語を元に文章を作成し、翻訳するサービスです
+				</p>
 				<div className="flex flex-col space-y-2">
 					<Button onClick={() => signIn("google")}>
 						<IconBrandGoogle className="mr-2" />
 						Googleアカウントで新規登録
 					</Button>
 				</div>
-				<AlertDialogDescription className="text-center">
-					新規登録の方はこちら
-				</AlertDialogDescription>
 			</AlertDialogContent>
 		</AlertDialog>
 	);

--- a/src/components/Layout/Header/SessionButton.tsx
+++ b/src/components/Layout/Header/SessionButton.tsx
@@ -6,7 +6,6 @@ import { useSession } from "next-auth/react";
 import { useEffect } from "react";
 import LoginModal from "./LoginModal";
 import Menu from "./Menu";
-import RegisterModal from "./RegisterModal";
 
 const SessionButton = () => {
 	const { data: session, status } = useSession();
@@ -39,7 +38,6 @@ const SessionButton = () => {
 						<IconSearch size={24} />
 					</div>
 					<LoginModal />
-					<RegisterModal />
 				</>
 			) : (
 				<>

--- a/src/components/Ui/AlertDialog.tsx
+++ b/src/components/Ui/AlertDialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
 		<AlertDialogPrimitive.Content
 			ref={ref}
 			className={cn(
-				"fixed left-[50%] top-[50%] z-50 grid w-full max-w-xs translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background rounded-lg p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:max-w-lg",
+				"fixed left-[50%] top-[50%] z-50 grid w-full max-w-xs translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background rounded-lg p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:max-w-md",
 				className,
 			)}
 			{...props}

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -35,7 +35,7 @@ export const authOptions: NextAuthOptions = {
 					where: { email: session.user.email },
 				});
 				if (userInfo) {
-					session.user.id = String(userInfo.id);
+					session.user.id = userInfo.id.toString();
 				}
 			}
 			return session;
@@ -43,23 +43,21 @@ export const authOptions: NextAuthOptions = {
 
 		async jwt({ token, user }) {
 			if (user) {
-				const userEmail = user.email as string;
 				const existingUser = await prisma.user.findUnique({
-					where: { email: userEmail },
+					where: { email: user.email },
 				});
 
 				if (!existingUser) {
-					const userName = user.name as string;
 					const newUser = await prisma.user.create({
 						data: {
-							email: userEmail,
-							name: userName,
+							email: user.email,
+							name: user.name,
 							password: "",
 						},
 					});
-					token.id = newUser.id;
+					token.id = newUser.id.toString();
 				} else {
-					token.id = existingUser.id;
+					token.id = existingUser.id.toString();
 				}
 			}
 			return token;
@@ -67,17 +65,15 @@ export const authOptions: NextAuthOptions = {
 	},
 	events: {
 		signIn: async ({ user }) => {
-			const userEmail = user.email as string;
 			const existingUser = await prisma.user.findUnique({
-				where: { email: userEmail },
+				where: { email: user.email },
 			});
 
 			if (!existingUser) {
-				const userName = user.name as string;
 				await prisma.user.create({
 					data: {
-						email: userEmail,
-						name: userName,
+						email: user.email,
+						name: user.name,
 						password: "",
 					},
 				});


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
Email認証のログインをなくす

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1] Headerでログインボタンのみに
- [変更点2] Googleアカウントのみの登録

## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [ ] Headerのデザインの変更
- [ ] ログイン変更

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->
- Closes #123
- Relates to #456

## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->
- [記事タイトル](リンク)
- [ドキュメントタイトル](リンク)

## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->
![スクリーンショットの説明](リンク)

## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->
今回はHeaderのデザインの変更を行った。おそらくsession関数をモックすればテストに支障が出ないとの見方に落ち着いたので


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ログインモーダルの機能が変更され、ユーザー認証入力が削除され、Googleサインインオプションが強調されるビジュアルプレゼンテーションに移行しました。
  
- **バグ修正**
  - セッションボタンから登録モーダルが削除され、直接登録するオプションが失われました。

- **スタイル**
  - アラートダイアログの最大幅が調整され、レイアウトが改善されました。

- **リファクタ**
  - 認証オプションのロジックが簡素化され、ユーザーデータの処理が一貫性を持つよう改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->