### PR TITLE
⚙️ Feat: 英単語の翻訳内容を表示

### DIFF
--- a/src/pages/api/texts/words.ts
+++ b/src/pages/api/texts/words.ts
@@ -1,0 +1,44 @@
+// pages/api/translate.ts
+
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+	req: NextApiRequest,
+	res: NextApiResponse,
+) {
+	if (req.method !== "POST") {
+		return res.status(405).json({ message: "Only POST requests are allowed" });
+	}
+
+	const { words } = req.body;
+
+	if (!words || !Array.isArray(words)) {
+		return res.status(400).json({ message: "Invalid request" });
+	}
+
+	const params = new URLSearchParams();
+	for (const word of words) {
+		params.append("text", word);
+	}
+	params.append("target_lang", "JA");
+
+	try {
+		const deeplResponse = await fetch(
+			"https://api-free.deepl.com/v2/translate",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `DeepL-Auth-Key ${process.env.DEEPL_API_KEY}`,
+					"Content-Type": "application/x-www-form-urlencoded",
+				},
+				body: params.toString(),
+			},
+		);
+
+		const data = await deeplResponse.json();
+		return res.status(200).json({ translations: data.translations });
+	} catch (error) {
+		console.error("Error translating words:", error);
+		return res.status(500).json({ message: "Translation failed" });
+	}
+}

--- a/src/pages/texts/[id]/components/Material.tsx
+++ b/src/pages/texts/[id]/components/Material.tsx
@@ -17,52 +17,54 @@ const Material = ({ words, level, theme }: MaterialProps) => {
 		[key: string]: string;
 	}>({});
 
-	useEffect(() => {
-		const translateWords = async () => {
-			try {
-				const response = await fetch("/api/texts/words", {
-					method: "POST",
-					headers: {
-						"Content-Type": "application/json",
-					},
-					body: JSON.stringify({ words }),
-				});
+	if (typeof window !== "undefined") {
+		useEffect(() => {
+			const translateWords = async () => {
+				try {
+					const response = await fetch("/api/texts/words", {
+						method: "POST",
+						headers: {
+							"Content-Type": "application/json",
+						},
+						body: JSON.stringify({ words }),
+					});
 
-				const data = await response.json();
+					const data = await response.json();
 
-				const translations = words.reduce(
-					(acc, word, index) => {
-						acc[word] = data.translations[index].text;
-						return acc;
-					},
-					{} as { [key: string]: string },
-				);
+					const translations = words.reduce(
+						(acc, word, index) => {
+							acc[word] = data.translations[index].text;
+							return acc;
+						},
+						{} as { [key: string]: string },
+					);
 
-				setTranslatedWords(translations);
-			} catch (error) {
-				console.error("Error fetching translation:", error);
-			}
-		};
+					setTranslatedWords(translations);
+				} catch (error) {
+					console.error("Error fetching translation:", error);
+				}
+			};
 
-		translateWords();
-	}, [words]);
+			translateWords();
+		}, [words]);
+	}
 
 	return (
 		<Accordion type="single" collapsible className="w-full">
 			<AccordionItem value="item-1">
 				<AccordionTrigger>使われた英単語・レベル・テーマ</AccordionTrigger>
 				<AccordionContent>
-					<ul className="ml-2 space-y-2">
-						<li>
-							<strong>英単語:</strong>
-						</li>
+					<ul className="ml-2 space-y-4">
+						<li className="text-xl font-bold">英単語</li>
 						{words.map((word) => (
 							<li key={word}>
 								{word}: {translatedWords[word] || "翻訳中..."}
 							</li>
 						))}
-						<li>レベル: {level}</li>
-						<li>テーマ: {theme}</li>
+						<li className="text-xl font-bold">レベル</li>
+						<li>{level}</li>
+						<li className="text-xl font-bold">テーマ</li>
+						<li>{theme}</li>
 					</ul>
 				</AccordionContent>
 			</AccordionItem>

--- a/src/pages/texts/[id]/components/Material.tsx
+++ b/src/pages/texts/[id]/components/Material.tsx
@@ -12,13 +12,13 @@ interface MaterialProps {
 	theme: string;
 }
 
-const Material = ({ words, level, theme }: MaterialProps) => {
+const Material = ({ words = [], level, theme }: MaterialProps) => {
 	const [translatedWords, setTranslatedWords] = useState<{
 		[key: string]: string;
 	}>({});
 
-	if (typeof window !== "undefined") {
-		useEffect(() => {
+	useEffect(() => {
+		if (words.length > 0) {
 			const translateWords = async () => {
 				try {
 					const response = await fetch("/api/texts/words", {
@@ -31,12 +31,11 @@ const Material = ({ words, level, theme }: MaterialProps) => {
 
 					const data = await response.json();
 
-					const translations = words.reduce(
-						(acc, word, index) => {
-							acc[word] = data.translations[index].text;
-							return acc;
-						},
-						{} as { [key: string]: string },
+					const translations = Object.fromEntries(
+						words.map((word, index) => [
+							word,
+							data.translations[index]?.text || "翻訳失敗",
+						]),
 					);
 
 					setTranslatedWords(translations);
@@ -46,7 +45,11 @@ const Material = ({ words, level, theme }: MaterialProps) => {
 			};
 
 			translateWords();
-		}, [words]);
+		}
+	}, [words]);
+
+	if (!words || words.length === 0) {
+		return <p>英単語のデータがありません。</p>;
 	}
 
 	return (

--- a/src/pages/texts/[id]/components/Material.tsx
+++ b/src/pages/texts/[id]/components/Material.tsx
@@ -1,0 +1,73 @@
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from "@/components/Ui/Accordion";
+import { useEffect, useState } from "react";
+
+interface MaterialProps {
+	words: string[];
+	level: string;
+	theme: string;
+}
+
+const Material = ({ words, level, theme }: MaterialProps) => {
+	const [translatedWords, setTranslatedWords] = useState<{
+		[key: string]: string;
+	}>({});
+
+	useEffect(() => {
+		const translateWords = async () => {
+			try {
+				const response = await fetch("/api/texts/words", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({ words }),
+				});
+
+				const data = await response.json();
+
+				const translations = words.reduce(
+					(acc, word, index) => {
+						acc[word] = data.translations[index].text;
+						return acc;
+					},
+					{} as { [key: string]: string },
+				);
+
+				setTranslatedWords(translations);
+			} catch (error) {
+				console.error("Error fetching translation:", error);
+			}
+		};
+
+		translateWords();
+	}, [words]);
+
+	return (
+		<Accordion type="single" collapsible className="w-full">
+			<AccordionItem value="item-1">
+				<AccordionTrigger>使われた英単語・レベル・テーマ</AccordionTrigger>
+				<AccordionContent>
+					<ul className="ml-2 space-y-2">
+						<li>
+							<strong>英単語:</strong>
+						</li>
+						{words.map((word) => (
+							<li key={word}>
+								{word}: {translatedWords[word] || "翻訳中..."}
+							</li>
+						))}
+						<li>レベル: {level}</li>
+						<li>テーマ: {theme}</li>
+					</ul>
+				</AccordionContent>
+			</AccordionItem>
+		</Accordion>
+	);
+};
+
+export default Material;

--- a/src/pages/texts/[id]/index.tsx
+++ b/src/pages/texts/[id]/index.tsx
@@ -1,7 +1,5 @@
-import {} from "@/components/Ui/Accordion";
 import type { TranslationTextProps } from "@/types/text";
 import type { GetStaticProps } from "next";
-import {} from "react";
 import AudioRecorder from "./components/AudioRecorder";
 import Material from "./components/Material";
 import Speech from "./components/Speech";

--- a/src/pages/texts/[id]/index.tsx
+++ b/src/pages/texts/[id]/index.tsx
@@ -1,12 +1,9 @@
-import {
-	Accordion,
-	AccordionContent,
-	AccordionItem,
-	AccordionTrigger,
-} from "@/components/Ui/Accordion";
+import {} from "@/components/Ui/Accordion";
 import type { TranslationTextProps } from "@/types/text";
 import type { GetStaticProps } from "next";
+import {} from "react";
 import AudioRecorder from "./components/AudioRecorder";
+import Material from "./components/Material";
 import Speech from "./components/Speech";
 import Translation from "./components/Translation";
 
@@ -20,18 +17,11 @@ const ModelSentence = ({ textData }: TranslationTextProps) => {
 					<AudioRecorder />
 				</div>
 				<Translation id={textData.id} ja={textData.ja} flag={textData.flag} />
-				<Accordion type="single" collapsible className="w-full">
-					<AccordionItem value="item-1">
-						<AccordionTrigger>使われた英単語・レベル・テーマ</AccordionTrigger>
-						<AccordionContent>
-							<ul className="ml-2 space-y-2">
-								<li>英単語: {textData.words.join(", ")}</li>
-								<li>レベル: {textData.level}</li>
-								<li>テーマ: {textData.theme}</li>
-							</ul>
-						</AccordionContent>
-					</AccordionItem>
-				</Accordion>
+				<Material
+					words={textData.words}
+					level={textData.level}
+					theme={textData.theme}
+				/>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
翻訳する際に英単語を表示できるように

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1] DeepLで英単語復数を翻訳してもらうようにした
- [変更点2] クライアントで翻訳した言葉を表記する

## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [ ] 正しく英単語が翻訳されている
- [ ] レンダリングを最小限にされていること

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->
- Closes #123
- Relates to #456

## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->
- [DeepL API](https://www.deepl.com/ja/pro-api)

## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->
[![Image from Gyazo](https://i.gyazo.com/def79a902332328daa5d248b17408a46.png)](https://gyazo.com/def79a902332328daa5d248b17408a46)

## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 日本語への単語翻訳を行うAPIエンドポイントを追加しました。
  - 英単語とその翻訳、レベル、テーマを表示する新しい`Material`コンポーネントを追加しました。

- **リファクタリング**
  - `ModelSentence`コンポーネントを改良し、`Accordion`コンポーネントを`Material`コンポーネントに置き換えました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->